### PR TITLE
Feature/31 add server environments

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  apps: [
+    {
+      name: 'NuxtAppName',
+      port: '3000',
+      exec_mode: 'cluster',
+      instances: 'max',
+      script: './.output/server/index.mjs'
+    }
+  ]
+}

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   apps: [
     {
-      name: 'NuxtAppName',
+      name: 'POLLmelo',
       port: '3000',
       exec_mode: 'cluster',
       instances: 'max',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "start": "nuxt start",
     "build": "nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",


### PR DESCRIPTION
For the prod Server the start command and the ecosystem is needed, because it is using pm2. Closing #31 