### PR TITLE
Small fix for individual poll view

### DIFF
--- a/components/PollItem.vue
+++ b/components/PollItem.vue
@@ -5,7 +5,7 @@
             <div class="w-1/4">
             </div>
             <div class="w-1/2 flex-none">
-                <div class="container flex-wrap items-center bg-pomelo-grey w-1/4 p-6 min-w-fit">
+                <div class="container w-full flex-wrap items-center bg-pomelo-grey w-1/4 p-6 min-w-fit">
                     <div class="font-bold w-full p-2 bg-white border-2 border-pomelo-red">
                       {{ this.name }}
                     </div>


### PR DESCRIPTION
Polls with a small description were not displayed in the center of their flexbox container. This PR fixes that.